### PR TITLE
fix:(diff): fix get function changes incorrect when the file added or deleted

### DIFF
--- a/src/utils/function_change/diff.ts
+++ b/src/utils/function_change/diff.ts
@@ -9,12 +9,19 @@ import { DiffFunctionInfo, FunctionInfo } from '../../type';
 
 // get the change of function before and after file change 
 export function getFunctionDiffInfo (filePath: string, commitSha?: string) {
-    const functionInfoNow = getFunctionBlock(filePath);
-
     let functionInfoBefore;
+    let functionInfoNow;
+
+    if (!fs.existsSync(filePath)) {  // file deleted
+        functionInfoNow = {};
+    } else {
+        functionInfoNow = getFunctionBlock(filePath);
+    }
+
     const blobId = getFileCtxBeforeChange(filePath, commitSha);
     if (!blobId) {
-        functionInfoBefore = functionInfoNow;
+        // treat it as a new file
+        functionInfoBefore = {};
     } else {
         const beforeCtx = execaCommandSync(`git cat-file blob ${blobId}`).stdout;
         const tempFile = `./temp_${path.posix.basename(filePath)}`;

--- a/src/utils/function_change/file_change.ts
+++ b/src/utils/function_change/file_change.ts
@@ -1,7 +1,7 @@
 import { execaCommandSync } from 'execa';
 import { FileChange } from '../../type';
 
-const COMMAND = 'git diff --name-status';
+const COMMANDS = ['git diff --name-status', 'git diff --name-status --staged'];
 
 const formatList = (str: string, type: string) => {
     const arr = str.split('\n').filter(item => {
@@ -22,11 +22,18 @@ export function getFileChange () {
 
     const typeList = ['M', 'D', 'A'];
     
-    const changeInfo = execaCommandSync(COMMAND).stdout;
+    for (const command of COMMANDS) {
+      const changeInfo = execaCommandSync(command).stdout;
 
-    typeList.forEach(type => {
-        result[type] = formatList(changeInfo, type)  
-    })
+      typeList.forEach(type => {
+        const formatResult = formatList(changeInfo, type);
+            if (result[type]) {
+                result[type].push(...formatResult);
+            } else {
+                result[type] = formatResult;
+            } 
+      });
+    }
 
     return result;
 }


### PR DESCRIPTION
## Problem

When the file is added or deleted, the function diff has no result.

## How to solve

- for added, use `git diff --name-status --staged` .File needs execute `git add` firstly
- for deleted, set `functionNow` as an empty object
