### PR TITLE
fix: fix function bloclk content incorrect while reading by lines

### DIFF
--- a/src/utils/function_change/diff.ts
+++ b/src/utils/function_change/diff.ts
@@ -42,7 +42,7 @@ function getFileLinesString (filePath: string, start: number, end: number): stri
     let line = liner.next();
 
     while (line) {
-        if (lineNumber >= start && lineNumber <= end) {
+        if (lineNumber >= (start - 1) && lineNumber <= (end - 1)) {
             result.push(line.toString());
         }
 


### PR DESCRIPTION
Fix function bloclk content incorrect while reading by lines. Beacuse the line was start with 0.